### PR TITLE
Channel page layout

### DIFF
--- a/my-app/src/containers/channelPage.js
+++ b/my-app/src/containers/channelPage.js
@@ -12,7 +12,7 @@ const ChannelPage = (props) => {
            <img src={props.location.data.channel.programme.contentUrl} height='50%' width='50%'></img>
            <h1>{props.location.data.channel.programme.title}</h1>
            <h2>{props.location.data.channel.programme.desc}</h2>
-           <Link to={{pathname: `/channel/:${props.location.data.channel.channelName}/chat`, data: props}}>
+           <Link to={{pathname: `/channel/:${props.location.data.channel.channelName}/chat`, data: props.location.data}}>
             <div>
               <h1>Join Chat</h1>
             </div>

--- a/my-app/src/containers/channelPage.js
+++ b/my-app/src/containers/channelPage.js
@@ -4,15 +4,15 @@ import Body from '../components/Body'
 import { Link } from 'react-router-dom'
 
 const ChannelPage = (props) => {
-  console.log(props)
+  const { channelName, channelIcon, programme: {contentUrl, title, desc} } = props.location.data.channel
     return (
       <div className="bg-washed-blue">
-          <Header headerTitle={props.location.data.channel.channelName} headerImage={props.location.data.channel.channelIcon}/>
+          <Header headerTitle={channelName} headerImage={channelIcon}/>
          <Body>
-           <img src={props.location.data.channel.programme.contentUrl} height='50%' width='50%'></img>
-           <h1>{props.location.data.channel.programme.title}</h1>
-           <h2>{props.location.data.channel.programme.desc}</h2>
-           <Link to={{pathname: `/channel/:${props.location.data.channel.channelName}/chat`, data: props.location.data}}>
+           <img src={contentUrl} height='50%' width='50%'></img>
+           <h1>{title}</h1>
+           <h2>{desc}</h2>
+           <Link to={{pathname: `/channel/:${channelName}/chat`, data: props.location.data}}>
             <div>
               <h1>Join Chat</h1>
             </div>

--- a/my-app/src/containers/channelPage.js
+++ b/my-app/src/containers/channelPage.js
@@ -12,12 +12,12 @@ const ChannelPage = (props) => {
            <img src={props.location.data.channel.programme.contentUrl} height='50%' width='50%'></img>
            <h1>{props.location.data.channel.programme.title}</h1>
            <h2>{props.location.data.channel.programme.desc}</h2>
-          </Body>
-          <Link to={{pathname: `/channel/:${props.location.data.channel.channelName}/chat`, data: props}}>
+           <Link to={{pathname: `/channel/:${props.location.data.channel.channelName}/chat`, data: props}}>
             <div>
               <h1>Join Chat</h1>
             </div>
           </Link>
+          </Body>
       </div>
     )
 }

--- a/my-app/src/containers/channelPage.js
+++ b/my-app/src/containers/channelPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Header from '../components/Header'
 import Body from '../components/Body'
+import { Link } from 'react-router-dom'
 
 const ChannelPage = (props) => {
   console.log(props)
@@ -8,8 +9,15 @@ const ChannelPage = (props) => {
       <div className="bg-washed-blue">
           <Header headerTitle={props.location.data.channel.channelName} headerImage={props.location.data.channel.channelIcon}/>
          <Body>
-           <h1>{props.location.data.channel.programme.description}</h1>  
+           <img src={props.location.data.channel.programme.contentUrl} height='50%' width='50%'></img>
+           <h1>{props.location.data.channel.programme.title}</h1>
+           <h2>{props.location.data.channel.programme.desc}</h2>
           </Body>
+          <Link to={{pathname: `/channel/:${props.location.data.channel.channelName}/chat`, data: props}}>
+            <div>
+              <h1>Join Chat</h1>
+            </div>
+          </Link>
       </div>
     )
 }


### PR DESCRIPTION
<img width="800" alt="Screen Shot 2019-03-28 at 10 23 40" src="https://user-images.githubusercontent.com/42212251/55150256-ac7c5980-5143-11e9-812e-14ec86096c81.png">

done channel page layout. going back from chat to channel page breaks due to data not being saved in channel pages state but passed by props