### PR TITLE
fixed Channel Page,  description is underneath image on small screens

### DIFF
--- a/my-app/src/css/channelPage.css
+++ b/my-app/src/css/channelPage.css
@@ -11,10 +11,23 @@
     width: 50%;
     height: auto;
     align-self: center;
+    margin-right: 10px;
 }
 
 
 .container {
     width: 40%;
+}
+
+@media(max-width: 768px) {
+    .flex-container {
+        flex-direction: column;
+    }
+    .image-wrapper {
+        width: 100%;
+    }
+    .container {
+        width: 100%;
+    }
 }
 


### PR DESCRIPTION
<img width="429" alt="Screenshot 2019-03-29 at 11 18 08" src="https://user-images.githubusercontent.com/42211383/55229245-59bea280-5214-11e9-9fa6-7d4368bb37d1.png">
